### PR TITLE
Feature: added view reservations page (SCRUM-79)

### DIFF
--- a/src/labels.ts
+++ b/src/labels.ts
@@ -12,6 +12,7 @@ export const LABELS = {
     CONTACT: 'Contact',
     OFFICE_SPACE: 'Office Space',
     RESERVE_DESK: 'Reserve a desk',
+    VIEW_RESERVATIONS: 'View Reservations',
     RESERVE_RESOURCES: 'Reserve Resource',
     RETURN_RESOURCES: 'Return Resources',
     MAINTENANCE: 'Request Maintenance',

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -52,6 +52,13 @@ export default function Header() {
           {LABELS.NAVIGATION.RESERVE_DESK}
         </button>
 
+        <button
+          onClick={() => handleNavigate('/reservations')}
+          className="text-gray-600 hover:text-gray-900 transition-colors font-medium text-left cursor-pointer"
+        >
+          {LABELS.NAVIGATION.VIEW_RESERVATIONS}
+        </button>
+
         {isAuthenticated ? (
           <>
             <button

--- a/src/services/reservationService.tsx
+++ b/src/services/reservationService.tsx
@@ -26,6 +26,14 @@ export async function fetchAllReservation(): Promise<ReservationResponseDTO[]> {
   return res.json();
 }
 
+export async function fetchPublicReservation(): Promise<
+  ReservationResponseDTO[]
+> {
+  const res = await fetch(`${BASE_URL}/public`);
+  if (!res.ok) throw new Error('Failed to fetch Reservation');
+  return res.json();
+}
+
 export async function fetchReservationByUserId(
   id: number,
 ): Promise<ReservationResponseDTO[]> {


### PR DESCRIPTION
Added view reservations page and you can view all public reservations and filter them by date.
Then if you swap it over to private it only shows your reservations


<img width="1719" height="1030" alt="image" src="https://github.com/user-attachments/assets/23219f00-618c-4954-ba31-6a06bf0c7b8e" />

Filtering by date always tries to find a reservation that works for your date range and can do just start date or just end date too
<img width="1865" height="1035" alt="image" src="https://github.com/user-attachments/assets/0fedf463-c573-41f1-b9a9-f8f2d60754bc" />

This should be all of the signed in users reservations I don't have a user to test it though: 
<img width="1846" height="932" alt="image" src="https://github.com/user-attachments/assets/07f3a099-1e21-4b40-8f80-0b6cfb008b7b" />

while its loading it shows a spinner: 
<img width="1873" height="1022" alt="image" src="https://github.com/user-attachments/assets/b8eeaf09-602c-49f1-8808-094c66bb7a7e" />
